### PR TITLE
remove deprecated dropdownPosition prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^14.2.0",
-    "@thirdweb-dev/react": "^4",
+    "@thirdweb-dev/react": "^4.4",
     "@thirdweb-dev/sdk": "^4",
     "ethers": "^5",
     "react": "^18.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,12 +26,7 @@ export default function Home() {
           </p>
 
           <div className="connect">
-            <ConnectWallet
-              dropdownPosition={{
-                side: "bottom",
-                align: "center",
-              }}
-            />
+            <ConnectWallet />
           </div>
         </div>
 


### PR DESCRIPTION
A [recent update](https://github.com/thirdweb-dev/js/commit/212b2e7bc28c8e88207a9935756f7e6133a5b7d3) to the ConnectWallet component removed the dropdownPosition prop. As a result there is a type error present in App.tsx due to use of this deprecated prop:

<img width="655" alt="Screenshot 2024-01-23 at 7 10 13 PM" src="https://github.com/thirdweb-example/vite-typescript-starter/assets/18269697/1dc1e50d-9685-4d18-9c2f-5360f735670d">


This update removes the reference to dropdownPosition prop in the ConnectWallet component.